### PR TITLE
Fix typo of `pronounceable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ Then, to test a word for pronounceability, use the `test` method.
 	console.log(pronounceable.test('xghsii')); // false
 ```
 
-You can also use the module to score a word on its pronounceability, using the `score` method. The higher the output value the more pronouncable the word.
+You can also use the module to score a word on its pronounceability, using the `score` method. The higher the output value the more pronounceable the word.
 
 ```
-	console.log(pronouncable.score('peonies')); // 0.10176356810708122
-	console.log(pronouncable.score('sshh')); // 0.0008556941146173743
+	console.log(pronounceable.score('peonies')); // 0.10176356810708122
+	console.log(pronounceable.score('sshh')); // 0.0008556941146173743
 ```
 
 To generate your own dataset use the `train` method.
 
 ```
-	pronouncable.train('dictionary.txt', function(probabilities) {
+	pronounceable.train('dictionary.txt', function(probabilities) {
 		// The data set has been returned
 		console.log(probabilities);
 	});


### PR DESCRIPTION
Fixes a typo in the README for this repo, which I discovered by pasting the code snippets.
